### PR TITLE
fix: apply the same context management to threaded transformer

### DIFF
--- a/laygo/transformers/parallel.py
+++ b/laygo/transformers/parallel.py
@@ -119,15 +119,14 @@ class ParallelTransformer[In, Out](Transformer[In, Out]):
 
   def _execute_with_context(self, data: Iterable[In], shared_context: MutableMapping[str, Any]) -> Iterator[Out]:
     """Helper to run the execution logic with a given context."""
-    with ProcessPoolExecutor(max_workers=self.max_workers) as executor:
-      executor = get_reusable_executor(max_workers=self.max_workers)
+    executor = get_reusable_executor(max_workers=self.max_workers)
 
-      chunks_to_process = self._chunk_generator(data)
-      gen_func = self._ordered_generator if self.ordered else self._unordered_generator
-      processed_chunks_iterator = gen_func(chunks_to_process, executor, shared_context)
+    chunks_to_process = self._chunk_generator(data)
+    gen_func = self._ordered_generator if self.ordered else self._unordered_generator
+    processed_chunks_iterator = gen_func(chunks_to_process, executor, shared_context)
 
-      for result_chunk in processed_chunks_iterator:
-        yield from result_chunk
+    for result_chunk in processed_chunks_iterator:
+      yield from result_chunk
 
   # ... The rest of the file remains the same ...
   def _ordered_generator(

--- a/tests/test_parallel_transformer.py
+++ b/tests/test_parallel_transformer.py
@@ -2,7 +2,6 @@
 
 import multiprocessing as mp
 import time
-from unittest.mock import patch
 
 from laygo import ErrorHandler
 from laygo import ParallelTransformer
@@ -158,19 +157,6 @@ class TestParallelTransformerOrderingAndPerformance:
 
     assert sorted(ordered_result) == sorted(unordered_result)
     assert ordered_result == [x * 2 for x in data]
-
-  def test_process_pool_management(self):
-    """Test that process pool is properly created and cleaned up."""
-    with patch("laygo.transformers.parallel.ProcessPoolExecutor") as mock_executor:
-      mock_executor.return_value.__enter__.return_value = mock_executor.return_value
-      mock_executor.return_value.__exit__.return_value = None
-      mock_executor.return_value.submit.return_value.result.return_value = [2, 4]
-      transformer = ParallelTransformer[int, int](max_workers=2, chunk_size=2)
-      list(transformer([1, 2]))
-
-      mock_executor.assert_called_with(max_workers=2)
-      mock_executor.return_value.__enter__.assert_called_once()
-      mock_executor.return_value.__exit__.assert_called_once()
 
 
 class TestParallelTransformerChunkingAndEdgeCases:


### PR DESCRIPTION
1. Implements true parallel executor
2. Implements global context manager so that it's all managed centrally and is process/thread safe
3. Creates factory methods for transformers to avoid type issues

Limitations: When running parallel processes, you can't pass functions from functions. All functions used by the process must be top level or custom pickling needs to happen.